### PR TITLE
stop cfn-init excecution on failure

### DIFF
--- a/modules/AWSQuickStart/AWSQuickStart.psm1
+++ b/modules/AWSQuickStart/AWSQuickStart.psm1
@@ -308,9 +308,11 @@ function Write-AWSQuickStartException {
         catch {
             Write-Verbose $_.Exception.Message
         }
-
-        Write-AWSQuickStartEvent -Message $errorMessage
-        throw $CmdSafeErrorMessage
+        finally {
+            Write-AWSQuickStartEvent -Message $errorMessage
+            # throwing an exception to force cfn-init execution to stop
+            throw $CmdSafeErrorMessage
+        }
     }
 }
 

--- a/modules/AWSQuickStart/AWSQuickStart.psm1
+++ b/modules/AWSQuickStart/AWSQuickStart.psm1
@@ -310,6 +310,7 @@ function Write-AWSQuickStartException {
         }
 
         Write-AWSQuickStartEvent -Message $errorMessage
+        throw $CmdSafeErrorMessage
     }
 }
 


### PR DESCRIPTION
prevents future cfn signals from masking failures