### PR TITLE
address intermittent credssp build failure

### DIFF
--- a/scripts/Create-ADServiceAccount.ps1
+++ b/scripts/Create-ADServiceAccount.ps1
@@ -29,6 +29,7 @@ try {
     $ErrorActionPreference = "Stop"
 
     $DomainAdminFullUser = $DomainNetBIOSName + '\' + $DomainAdminUser
+    $ServiceAccountFullUser = $DomainNetBIOSName + '\' + $ServiceAccountUser
     $DomainAdminSecurePassword = ConvertTo-SecureString $DomainAdminPassword -AsPlainText -Force
     $DomainAdminCreds = New-Object System.Management.Automation.PSCredential($DomainAdminFullUser, $DomainAdminSecurePassword)
     $ServiceAccountSecurePassword = ConvertTo-SecureString $ServiceAccountPassword -AsPlainText -Force
@@ -37,11 +38,12 @@ try {
         $ErrorActionPreference = "Stop"
         try {
             Get-ADUser -Identity $Using:ServiceAccountUser
-            Set-ADAccountPassword -Identity $Using:ServiceAccountUser -Reset -NewPassword $Using:ServiceAccountSecurePassword
-            Set-ADUser -Identity $Using:ServiceAccountUser -PasswordNeverExpires $true -Enabled $true
         }
         catch {
             New-ADUser -Name $Using:ServiceAccountUser -UserPrincipalName $Using:UserPrincipalName -AccountPassword $Using:ServiceAccountSecurePassword -Enabled $true -PasswordNeverExpires $true
+        }
+        if ((new-object directoryservices.directoryentry "", $Using:ServiceAccountFullUser, $Using:ServiceAccountPassword).psbase.name -eq $null){
+            throw "Password for $Using:ServiceAccountUser is not valid"
         }
 
     }

--- a/scripts/Create-ADServiceAccount.ps1
+++ b/scripts/Create-ADServiceAccount.ps1
@@ -37,9 +37,11 @@ try {
         $ErrorActionPreference = "Stop"
         try {
             Get-ADUser -Identity $Using:ServiceAccountUser
+            Set-ADAccountPassword -Identity $Using:ServiceAccountUser -Reset -NewPassword $Using:ServiceAccountSecurePassword
+            Set-ADUser -Identity $Using:ServiceAccountUser -PasswordNeverExpires $true -Enabled $true
         }
         catch {
-            New-ADUser -Name $Using:ServiceAccountUser -UserPrincipalName $Using:UserPrincipalName -AccountPassword $Using:ServiceAccountSecurePassword -Enabled $true -PasswordNeverExpires $true -EA 0
+            New-ADUser -Name $Using:ServiceAccountUser -UserPrincipalName $Using:UserPrincipalName -AccountPassword $Using:ServiceAccountSecurePassword -Enabled $true -PasswordNeverExpires $true
         }
 
     }

--- a/scripts/Create-ADServiceAccount.ps1
+++ b/scripts/Create-ADServiceAccount.ps1
@@ -35,7 +35,13 @@ try {
     $UserPrincipalName = $ServiceAccountUser + "@" + $DomainDNSName
     $CreateUserPs={
         $ErrorActionPreference = "Stop"
-        New-ADUser -Name $Using:ServiceAccountUser -UserPrincipalName $Using:UserPrincipalName -AccountPassword $Using:ServiceAccountSecurePassword -Enabled $true -PasswordNeverExpires $true -EA 0
+        try {
+            Get-ADUser -Identity $Using:ServiceAccountUser
+        }
+        catch {
+            New-ADUser -Name $Using:ServiceAccountUser -UserPrincipalName $Using:UserPrincipalName -AccountPassword $Using:ServiceAccountSecurePassword -Enabled $true -PasswordNeverExpires $true -EA 0
+        }
+
     }
     Invoke-Command -Scriptblock $CreateUserPs -ComputerName $ADServerNetBIOSName -Credential $DomainAdminCreds
 }

--- a/scripts/DisableCredSsp.ps1
+++ b/scripts/DisableCredSsp.ps1
@@ -5,8 +5,10 @@ try {
     Disable-WSManCredSSP Client
     Disable-WSManCredSSP Server
 
-    Remove-Item -Path 'hklm:\SOFTWARE\Policies\Microsoft\Windows\CredentialsDelegation\AllowFreshCredentialsWhenNTLMOnly'
-    Remove-ItemProperty -Path 'hklm:\SOFTWARE\Policies\Microsoft\Windows\CredentialsDelegation' -Name 'AllowFreshCredentialsWhenNTLMOnly'
+    Remove-Item -Path 'hklm:\SOFTWARE\Policies\Microsoft\Windows\CredentialsDelegation\AllowFreshCredentials' -ErrorAction Ignore
+    Remove-ItemProperty -Path 'hklm:\SOFTWARE\Policies\Microsoft\Windows\CredentialsDelegation' -Name 'AllowFreshCredentials' -ErrorAction Ignore
+    Remove-Item -Path 'hklm:\SOFTWARE\Policies\Microsoft\Windows\CredentialsDelegation\AllowFreshCredentialsWhenNTLMOnly' -ErrorAction Ignore
+    Remove-ItemProperty -Path 'hklm:\SOFTWARE\Policies\Microsoft\Windows\CredentialsDelegation' -Name 'AllowFreshCredentialsWhenNTLMOnly' -ErrorAction Ignore
 }
 catch {
     $_ | Write-AWSQuickStartException

--- a/scripts/EnableCredSsp.ps1
+++ b/scripts/EnableCredSsp.ps1
@@ -2,6 +2,9 @@
 param(
 
     [Parameter(Mandatory=$false)]
+    [string]$DomainNetBIOSName,
+
+    [Parameter(Mandatory=$false)]
     [string]$DomainDNSName,
 
     [Parameter(Mandatory=$false)]
@@ -13,20 +16,35 @@ try {
     $ErrorActionPreference = "Stop"
 
     Enable-WSManCredSSP Client -DelegateComputer $ServerName -Force
+    if ($DomainNetBIOSName) {
+        Enable-WSManCredSSP Client -DelegateComputer *.$DomainNetBIOSName -Force
+    }
     if ($DomainDNSName) {
         Enable-WSManCredSSP Client -DelegateComputer *.$DomainDNSName -Force
     }
     Enable-WSManCredSSP Server -Force
 
+    # Sometimes Enable-WSManCredSSP doesn't get it right, so we set some registry entries by hand
     $parentkey = "hklm:\SOFTWARE\Policies\Microsoft\Windows"
     $key = "$parentkey\CredentialsDelegation"
+    $freshkey = "$key\AllowFreshCredentials"
     $ntlmkey = "$key\AllowFreshCredentialsWhenNTLMOnly"
     New-Item -Path $parentkey -Name 'CredentialsDelegation' -Force
+    New-Item -Path $key -Name 'AllowFreshCredentials' -Force
     New-Item -Path $key -Name 'AllowFreshCredentialsWhenNTLMOnly' -Force
+    New-ItemProperty -Path $key -Name AllowFreshCredentials -Value 1 -PropertyType Dword -Force
+    New-ItemProperty -Path $key -Name ConcatenateDefaults_AllowFresh -Value 1 -PropertyType Dword -Force
     New-ItemProperty -Path $key -Name AllowFreshCredentialsWhenNTLMOnly -Value 1 -PropertyType Dword -Force
+    New-ItemProperty -Path $key -Name ConcatenateDefaults_AllowFreshNTLMOnly -Value 1 -PropertyType Dword -Force
+    New-ItemProperty -Path $freshkey -Name 1 -Value "WSMAN/$ServerName" -PropertyType String -Force
     New-ItemProperty -Path $ntlmkey -Name 1 -Value "WSMAN/$ServerName" -PropertyType String -Force
+    if ($DomainNetBIOSName) {
+        New-ItemProperty -Path $freshkey -Name 2 -Value "WSMAN/$ServerName.$DomainNetBIOSName" -PropertyType String -Force
+        New-ItemProperty -Path $ntlmkey -Name 2 -Value "WSMAN/$ServerName.$DomainNetBIOSName" -PropertyType String -Force
+    }
     if ($DomainDNSName) {
-        New-ItemProperty -Path $ntlmkey -Name 2 -Value "WSMAN/*.$DomainDNSName" -PropertyType String -Force
+        New-ItemProperty -Path $freshkey -Name 2 -Value "WSMAN/$ServerName.$DomainDNSName" -PropertyType String -Force
+        New-ItemProperty -Path $ntlmkey -Name 2 -Value "WSMAN/$ServerName.$DomainDNSName" -PropertyType String -Force
     }
 
 }


### PR DESCRIPTION
Turns out when adding certain registry keys in a certain order entries for AllowFreshCredentials are removed. AllowFreshCredentials seems to be needed ~5% of the time.

Reworked how the keys are added and explicitly add keys for AllowFreshCredentials.