### PR TITLE
adding checks for registry values

### DIFF
--- a/scripts/Enable-AutoLogon.ps1
+++ b/scripts/Enable-AutoLogon.ps1
@@ -17,19 +17,31 @@ try {
     $winlogon = Get-Item -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon'
 
     # Check for the AutoAdminLogon value and it's current status before applying.
-    If(-Not($winlogon.GetValue("AutoAdminLogon") -eq "1")) {
+    try {
+        If(-Not($winlogon.GetValue("AutoAdminLogon") -eq "1")) {
+            New-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon' -Name AutoAdminLogon -Value 1 -ErrorAction Stop | Out-Null
+        } else { write "AutoAdminLogon already set to 1" }
+    } catch {
         New-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon' -Name AutoAdminLogon -Value 1 -ErrorAction Stop | Out-Null
-    } else { write "AutoAdminLogon already set to 1" }
+    }
 
     # Check for the DefaultUserName before applying
-    If(-Not($winlogon.GetValue("DefaultUserName").split('@')[0] -eq $UserName)) {
+    try {
+        If(-Not($winlogon.GetValue("DefaultUserName").split('@')[0] -eq $UserName)) {
+            New-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon' -Name DefaultUserName -Value $UserName -ErrorAction Stop | Out-Null
+        } else { write "DefaultUserName is already set" }
+    } catch {
         New-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon' -Name DefaultUserName -Value $UserName -ErrorAction Stop | Out-Null
-    } else { write "DefaultUserName is already set" }
+    }
 
     # Check for the DefaultPassword before applying
-    If(-Not($winlogon.GetValue("DefaultPassword") -eq "$Password")) {
+    try {
+        If(-Not($winlogon.GetValue("DefaultPassword") -eq "$Password")) {
+            New-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon' -Name DefaultPassword -Value $Password -ErrorAction Stop | Out-Null
+        } else { write "DefaultPassword already set" }
+    } catch {
         New-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon' -Name DefaultPassword -Value $Password -ErrorAction Stop | Out-Null
-    } else { write "DefaultPassword already set" }
+    }
 
     # Add a startup script if specified
     if (-not [string]::IsNullOrEmpty($StartupScript)) {

--- a/scripts/Enable-AutoLogon.ps1
+++ b/scripts/Enable-AutoLogon.ps1
@@ -14,9 +14,24 @@ param (
 )
 
 try {
-    New-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon' -Name AutoAdminLogon -Value 1 -ErrorAction Stop | Out-Null
-    New-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon' -Name DefaultUserName -Value $UserName -ErrorAction Stop | Out-Null
-    New-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon' -Name DefaultPassword -Value $Password -ErrorAction Stop | Out-Null
+    $winlogon = Get-Item -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon'
+
+    # Check for the AutoAdminLogon value and it's current status before applying.
+    If(-Not($winlogon.GetValue("AutoAdminLogon") -eq "1")) {
+        New-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon' -Name AutoAdminLogon -Value 1 -ErrorAction Stop | Out-Null
+    } else { write "AutoAdminLogon already set to 1" }
+
+    # Check for the DefaultUserName before applying
+    If(-Not($winlogon.GetValue("DefaultUserName").split('@')[0] -eq $UserName)) {
+        New-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon' -Name DefaultUserName -Value $UserName -ErrorAction Stop | Out-Null
+    } else { write "DefaultUserName is already set" }
+
+    # Check for the DefaultPassword before applying
+    If(-Not($winlogon.GetValue("DefaultPassword") -eq "$Password")) {
+        New-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon' -Name DefaultPassword -Value $Password -ErrorAction Stop | Out-Null
+    } else { write "DefaultPassword already set" }
+
+    # Add a startup script if specified
     if (-not [string]::IsNullOrEmpty($StartupScript)) {
         New-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce' -Name Install -Value $StartupScript -ErrorAction Stop | Out-Null
     }


### PR DESCRIPTION
upon re-running cfn-init for 2012r2 I get failures because the values exist, I added checks for the various keys/values and now I can re-run cfn-init